### PR TITLE
Refactor JobShop wrapper

### DIFF
--- a/mava/wrappers/job_shop_wrapper.py
+++ b/mava/wrappers/job_shop_wrapper.py
@@ -1,27 +1,19 @@
-from abc import ABC, abstractmethod
 from functools import cached_property
-from typing import Any, Tuple, Dict, NamedTuple
-import jax
+from typing import Any, Dict, Tuple
+
 import jax.numpy as jnp
+from jumanji import specs
 from jumanji.env import Environment
 from jumanji.environments.packing.job_shop import JobShop, State
 from jumanji.environments.packing.job_shop.generator import RandomGenerator
 from jumanji.types import TimeStep
-from jumanji.wrappers import Wrapper
 import logging
+
 from mava.types import Observation, ObservationGlobalState
-from dm_env import specs
+from mava.wrappers.jumanji import JumanjiMarlWrapper
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
-
-class ObservationSpec(NamedTuple):
-    specs: Dict[str, specs.Array]
-
-    def generate_value(self) -> Observation:
-        return Observation(
-            **{key: spec.generate_value() for key, spec in self.specs.items() if spec is not None}
-        )
 
 class JobShopPatched(JobShop):
     def __init__(self, num_jobs: int, num_machines: int, max_num_ops: int, max_op_duration: int):
@@ -41,92 +33,73 @@ class JobShopPatched(JobShop):
     def step(self, state: State, action: jnp.ndarray) -> Tuple[State, TimeStep]:
         return super().step(state, action)
 
-class JumanjiMarlWrapper(Wrapper, ABC):
-    def __init__(self, env: Environment, add_global_state: bool = False):
-        super().__init__(env)
-        self.add_global_state = add_global_state
-        self.num_agents = env.num_machines
-        self.action_dim = self.num_agents
-        self.time_limit = getattr(env, "time_limit", None)
-        if self.time_limit is None:
-            nj = getattr(env, "num_jobs", 5)
-            mo = getattr(env, "max_num_ops", 4)
-            md = getattr(env, "max_op_duration", 4)
-            self.time_limit = nj * mo * md
-
-    @abstractmethod
-    def reset(self) -> Tuple[Any, Observation]:
-        ...
-
-    @abstractmethod
-    def step(self, state: Any, action: Any) -> Tuple[Any, TimeStep]:
-        ...
 
 class JobShopWrapper(JumanjiMarlWrapper):
+    """Multi-agent wrapper for the JobShop environment."""
+
     def __init__(self, env: Environment, add_global_state: bool = False):
         super().__init__(env, add_global_state)
+        self._env: JobShop
 
-    def reset(self) -> Tuple[State, TimeStep]:
-        state, ts = self._env.reset()
-        mava_obs = self._to_mava_obs(ts.observation)
-        ts = ts.replace(observation=mava_obs)
-        return state, ts
+    def modify_timestep(self, timestep: TimeStep) -> TimeStep[Observation]:
+        """Convert Jumanji observation to a Mava observation."""
 
-    def step(self, state: State, action: jnp.ndarray) -> Tuple[State, TimeStep]:
-        state, ts = super().step(state, action)
-        mava_obs = self._to_mava_obs(ts.observation)
-        ts = ts.replace(observation=mava_obs)
-        return state, ts
+        obs = timestep.observation
+        agents_view = jnp.concatenate(
+            [obs.machines.astype(float), obs.jobs.astype(float)],
+            axis=-1,
+        )
 
-    def _to_mava_obs(self, jumanji_obs) -> Observation:
-        # Example conversion: adapt based on JobShop's observation structure
-        # Jumanji's Observation has 'machines', 'jobs', 'action_mask', etc.
-        agents_view = jnp.concatenate([jumanji_obs.machines, jumanji_obs.jobs], axis=-1)
-        action_mask = jumanji_obs.action_mask
-        step_count = jumanji_obs.step_count
-        if self.add_global_state:
-            gs = self.get_global_state(Observation(
-                agents_view=agents_view,
-                action_mask=action_mask,
-                step_count=step_count
-            ))
-            return ObservationGlobalState(
-                global_state=gs,
-                agents_view=agents_view,
-                action_mask=action_mask,
-                step_count=step_count
-            )
-        return Observation(
+        observation = Observation(
             agents_view=agents_view,
-            action_mask=action_mask,
-            step_count=step_count
+            action_mask=obs.action_mask,
+            step_count=jnp.repeat(obs.step_count, self.num_agents),
+        )
+
+        reward = jnp.repeat(timestep.reward, self.num_agents)
+        discount = jnp.repeat(timestep.discount, self.num_agents)
+        metrics: Dict[str, Any] = {"env_metrics": {}}
+
+        return timestep.replace(
+            observation=observation, reward=reward, discount=discount, extras=metrics
         )
 
     @cached_property
-    def observation_spec(self) -> ObservationSpec:
-        # Define based on actual Jumanji observation structure
-        jumanji_obs_spec = self._env.observation_spec
-        machine_shape = jumanji_obs_spec.machines.shape
-        job_shape = jumanji_obs_spec.jobs.shape
-        feat = machine_shape[-1] + job_shape[-1]  # Concatenated features
-        specs_map = {
-            "agents_view": specs.BoundedArray(
-                shape=(self.num_agents, feat),
-                dtype=jnp.float32,
-                minimum=0.0,
-                maximum=float('inf'),  # Adjust based on data
-                name="agents_view",
-            ),
-            "action_mask": jumanji_obs_spec.action_mask,
-            "step_count": jumanji_obs_spec.step_count,
+    def observation_spec(self) -> specs.Spec:
+        """Specification of the environment observations."""
+
+        spec = self._env.observation_spec
+        machine_feat = spec.machines.shape[-1]
+        job_feat = spec.jobs.shape[-1]
+        feat = machine_feat + job_feat
+
+        agents_view = specs.Array(
+            (self.num_agents, feat), spec.machines.dtype, "agents_view"
+        )
+
+        step_count = specs.BoundedArray(
+            (self.num_agents,),
+            int,
+            jnp.zeros(self.num_agents, dtype=int),
+            jnp.repeat(self.time_limit, self.num_agents),
+            "step_count",
+        )
+
+        obs_data = {
+            "agents_view": agents_view,
+            "action_mask": spec.action_mask,
+            "step_count": step_count,
         }
+
         if self.add_global_state:
-            specs_map["global_state"] = specs.Array(
-                shape=(self.num_agents, feat * self.num_agents),
-                dtype=jnp.float32,
-                name="global_state",
+            obs_data["global_state"] = specs.Array(
+                (self.num_agents, self.num_agents * feat),
+                spec.machines.dtype,
+                "global_state",
             )
-        return ObservationSpec(specs=specs_map)
+            return specs.Spec(ObservationGlobalState, "ObservationSpec", **obs_data)
+
+        return specs.Spec(Observation, "ObservationSpec", **obs_data)
 
     @cached_property
     def action_spec(self) -> specs.DiscreteArray:


### PR DESCRIPTION
## Summary
- import common JumanjiMarlWrapper in JobShop wrapper
- rewrite JobShopWrapper using modify_timestep pattern
- construct observation specs with jumanji spec objects
- keep JobShop registered in environment factory

## Testing
- `pytest -k job_shop_wrapper -q` *(fails: ModuleNotFoundError: No module named 'hydra')*

------
https://chatgpt.com/codex/tasks/task_e_68603a0558388321bdaa9af8ef6e4768